### PR TITLE
feat: Implement email ingestion via apple-mcp

### DIFF
--- a/.claude/commands/email-check.md
+++ b/.claude/commands/email-check.md
@@ -1,0 +1,83 @@
+# /email-check
+
+Process emails as project updates via the apple-mcp email integration.
+
+## Usage
+
+```
+/email-check
+```
+
+This command:
+1. Reads emails using mcp_email_read
+2. Analyzes them for project-relevant content
+3. Suggests updates to project files (does NOT auto-update)
+4. Maintains human control over what gets incorporated
+
+## Manager Mode
+
+When run at the manager level (~projects/), it:
+- Scans all emails for project-related content
+- Groups suggestions by project
+- Proposes brain-dump style updates for routing
+
+## Project Mode  
+
+When run within a project directory, it:
+- Filters emails for this project's context
+- Suggests updates to PROJECT_ROADMAP.md
+- Identifies action items and deadlines
+- Extracts decisions and blockers
+
+## Philosophy
+
+This follows the MCP integration pattern:
+- **Email is the primitive** - We read, not manage
+- **Human decides** - All updates are suggestions
+- **Project memory focused** - Extract what matters for CLAUDE_LOG and roadmap
+- **No automation** - You review and approve each suggestion
+
+## Example Output
+
+```
+## Email Check - 3 relevant emails found
+
+### Project: auth-service
+**From: client@example.com - "Re: Auth deployment timeline"**
+Suggested roadmap update:
+- Add to Active Work: "Deploy auth to staging [DUE: 2024-03-15]"
+- Note: Client confirmed March 15th deadline
+
+### Project: blog  
+**From: team@company.com - "Blog post schedule"**
+Suggested log entry:
+- Marketing wants claudepm article by Friday
+- Add to roadmap: "Write claudepm announcement post [DUE: 2024-03-10]"
+
+### General
+**From: manager@company.com - "Team standup time change"**
+No specific project - for your awareness:
+- Daily standup moving to 10am starting Monday
+```
+
+## Implementation
+
+```bash
+# Read emails from the last 24 hours
+emails=$(mcp_email_read --since "24 hours ago")
+
+# Analyze for project content
+echo "$emails" | claude-code -p "Analyze these emails for project updates:
+1. Identify which projects are mentioned
+2. Extract deadlines, decisions, and action items  
+3. Suggest specific updates to PROJECT_ROADMAP.md or CLAUDE_LOG.md
+4. Group by project
+5. Present as review-and-approve suggestions"
+```
+
+## Notes
+
+- Emails are never deleted or marked as read
+- Suggestions can be ignored if not relevant
+- Works best with clear subject lines mentioning project names
+- Run daily for best results

--- a/CLAUDE_LOG.md
+++ b/CLAUDE_LOG.md
@@ -812,3 +812,16 @@ Next: Commit these changes and create PR
 Notes: This change solves Claude's security limitation - can't access ../dirs but CAN access worktrees/
 
 ---
+
+
+### 2025-07-01 16:23 - [feature/email-ingestion] - Implemented email ingestion via apple-mcp
+Did:
+- CREATED: /email-check command in .claude/commands/email-check.md
+- UPDATED: templates/manager/CLAUDE.md - added /email-check to slash commands list
+- UPDATED: templates/project/CLAUDE.md - added Available Slash Commands section with /email-check
+- UPDATED: PROJECT_ROADMAP.md - added email ingestion to v0.7 section with full details
+- TESTED: Read all files to verify correct implementation
+Next: Commit changes and create PR back to dev branch
+Notes: Implementation follows Gemini's architectural plan exactly. Maintains MCP philosophy of primitives over workflows. Human approval required for all suggested updates.
+
+---

--- a/PROJECT_ROADMAP.md
+++ b/PROJECT_ROADMAP.md
@@ -144,6 +144,7 @@ A minimal memory system for Claude Code using three markdown files. The complete
   - `/project-health` - Which projects need attention?
   - `/start-work [project]` - Quick briefing before diving into project
   - `/brain-dump` - Process unstructured updates and route to projects
+  - `/email-check` - Process emails as project updates via apple-mcp
 - [ ] Sub-agent report generation pattern
   - Manager spawns one agent per project for deep analysis
   - Each agent reads three documents + git history
@@ -157,6 +158,15 @@ A minimal memory system for Claude Code using three markdown files. The complete
   - FUTURE: Automated report saving after processing
   - FUTURE: Batch processing of multiple updates
   - NOTE: Core functionality works today through Claude's intelligence, not code
+- [ ] **Email Ingestion via apple-mcp** (Project Updates from Email)
+  - ALREADY WORKS: MCP servers provide email reading capability
+  - NEW: /email-check command processes emails as project updates
+  - Filters emails for project-relevant content
+  - Suggests (never auto-updates) changes to PROJECT_ROADMAP.md
+  - Extracts deadlines, decisions, and blockers
+  - Manager mode: Routes email updates to appropriate projects
+  - Project mode: Filters for project-specific emails only
+  - Philosophy: Email is a read-only source; humans approve all changes
 - [ ] **Manager Report Persistence** (Hierarchical Memory)
   - Save daily summaries to `~/.claudepm/reports/daily/YYYY-MM-DD.md`
   - Save weekly summaries to `~/.claudepm/reports/weekly/`

--- a/templates/manager/CLAUDE.md
+++ b/templates/manager/CLAUDE.md
@@ -316,6 +316,9 @@ Which projects need attention? Check for blockers and stale work
 ### /start-work [project]
 Quick briefing before diving into a specific project
 
+### /email-check
+Process emails as project updates via apple-mcp integration. Reads emails and suggests updates to project files without auto-updating. Maintains human control over what gets incorporated.
+
 **Note**: These commands are stored in `.claude/commands/*.md` and can be customized or extended.
 See https://www.anthropic.com/engineering/claude-code-best-practices for more on slash commands.
 

--- a/templates/project/CLAUDE.md
+++ b/templates/project/CLAUDE.md
@@ -63,6 +63,13 @@ Type: [Web app, CLI tool, library, etc.]
 Language: [Python, JS, etc.]
 Purpose: [What this project does]
 
+## Available Slash Commands
+
+When working in this project, these commands are available:
+
+### /email-check
+Process emails related to this specific project. Filters emails for project context and suggests updates to PROJECT_ROADMAP.md. Identifies action items, deadlines, decisions, and blockers without auto-updating files.
+
 <!-- 
 CLAUDE.md is for HOW - behavioral instructions
 Add project-specific workflows, commands, and conventions below


### PR DESCRIPTION
## Summary
- Implemented the /email-check slash command for processing emails as project updates
- Follows Gemini's architectural plan for MCP integration
- Maintains human control over all updates (suggestions only, no automation)

## Implementation Details

### Created Files
- `.claude/commands/email-check.md` - The slash command implementation

### Updated Files
- `templates/manager/CLAUDE.md` - Added /email-check to slash commands list
- `templates/project/CLAUDE.md` - Added Available Slash Commands section with /email-check
- `PROJECT_ROADMAP.md` - Added email ingestion feature to v0.7 section

## How It Works

1. **Manager Mode**: When run at ~/projects level, scans all emails and suggests routing to appropriate projects
2. **Project Mode**: When run within a project, filters for project-specific emails only
3. **Philosophy**: Email reading is the primitive (via apple-mcp), Claude orchestrates the analysis and suggestions
4. **Human Control**: All updates are presented as suggestions for review and approval

## Test Plan
- [x] Created slash command file with proper documentation
- [x] Updated both manager and project templates
- [x] Added to roadmap with implementation details
- [x] Verified all files are syntactically correct
- [ ] Test with actual apple-mcp integration once available
- [ ] Verify email filtering works correctly in both modes

🤖 Generated with [Claude Code](https://claude.ai/code)